### PR TITLE
Make livy compatible with python 3.8+

### DIFF
--- a/repl/src/main/resources/fake_shell.py
+++ b/repl/src/main/resources/fake_shell.py
@@ -219,7 +219,10 @@ class NormalNode(object):
 
         try:
             for node in to_run_exec:
-                mod = ast.Module([node])
+                if sys.version_info >= (3, 8):
+                    mod = ast.Module([node], [])
+                else:
+                    mod = ast.Module([node])
                 code = compile(mod, '<stdin>', 'exec')
                 exec(code, global_dict)
 


### PR DESCRIPTION
Changes to make livy work with python 3.8+