### PR TITLE
exclude prophecy-libs from REPL classloader to fix double classloader issue

### DIFF
--- a/repl/scala-2.13/src/main/scala/org/apache/livy/repl/SparkInterpreter.scala
+++ b/repl/scala-2.13/src/main/scala/org/apache/livy/repl/SparkInterpreter.scala
@@ -81,6 +81,9 @@ class SparkInterpreter(protected override val conf: SparkConf) extends AbstractS
             .filterNot { u =>
               Paths.get(u.toURI).getFileName.toString.contains("org.scala-lang_scala-reflect")
             }
+            .filterNot { u =>
+              Paths.get(u.toURI).getFileName.toString.contains("prophecy-libs")
+            }
 
           extraJarPath.foreach { p => debug(s"Adding $p to Scala interpreter's class path...") }
           sparkILoop.intp.addUrlsToClassPath(extraJarPath: _*)
@@ -104,7 +107,11 @@ class SparkInterpreter(protected override val conf: SparkConf) extends AbstractS
   }
 
   override def addJar(jar: String): Unit = {
-    sparkILoop.intp.addUrlsToClassPath(new URL(jar))
+    if (jar.contains("prophecy-libs")) {
+      info(s"Skipping REPL classpath addition for $jar (parent-classloader-only)")
+    } else {
+      sparkILoop.intp.addUrlsToClassPath(new URL(jar))
+    }
   }
 
   override protected def isStarted(): Boolean = {


### PR DESCRIPTION
On Spark 4

Spark 4's Scala REPL uses a child-first classloader (ScalaClassLoader$URLClassLoader) that loads its own copy of prophecy-libs classes independently from the parent MutableURLClassLoader. This causes ClassCastException when the SparkListener tries to cast InterimRow objects across classloader boundaries. Excluding prophecy-libs from the REPL classpath forces parent-first delegation so both sides share the same class identity.

## What changes were proposed in this pull request?

(Please fill in changes proposed in this fix)
(Include a link to the associated JIRA and make sure to add a link to this pr on the JIRA as well)

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)
(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

Please review https://livy.incubator.apache.org/community/ before opening a pull request.


https://app.asana.com/1/711615303573503/project/1201492708519695/task/1213827272857555?focus=true
https://app.asana.com/1/711615303573503/project/1201492708519695/task/1213746931330542?focus=true
