### PR TITLE
add prophecy-libs to REPL compiler classpath only

### DIFF
--- a/repl/scala-2.13/src/main/scala/org/apache/livy/repl/SparkInterpreter.scala
+++ b/repl/scala-2.13/src/main/scala/org/apache/livy/repl/SparkInterpreter.scala
@@ -82,8 +82,15 @@ class SparkInterpreter(protected override val conf: SparkConf) extends AbstractS
               Paths.get(u.toURI).getFileName.toString.contains("org.scala-lang_scala-reflect")
             }
 
-          extraJarPath.foreach { p => debug(s"Adding $p to Scala interpreter's class path...") }
-          sparkILoop.intp.addUrlsToClassPath(extraJarPath: _*)
+          val (prophecyJars, otherJars) = extraJarPath.partition { u =>
+            Paths.get(u.toURI).getFileName.toString.contains("prophecy-libs")
+          }
+          otherJars.foreach { p => debug(s"Adding $p to Scala interpreter's class path...") }
+          sparkILoop.intp.addUrlsToClassPath(otherJars: _*)
+          if (prophecyJars.nonEmpty) {
+            prophecyJars.foreach { p => debug(s"Adding $p to compiler classpath only...") }
+            sparkILoop.intp.global.extendCompilerClassPath(prophecyJars: _*)
+          }
           classLoader = null
         } else {
           classLoader = classLoader.getParent
@@ -104,7 +111,16 @@ class SparkInterpreter(protected override val conf: SparkConf) extends AbstractS
   }
 
   override def addJar(jar: String): Unit = {
-    sparkILoop.intp.addUrlsToClassPath(new URL(jar))
+    val url = new URL(jar)
+    if (jar.contains("prophecy-libs")) {
+      // Add to compiler classpath only — not the REPL runtime classloader.
+      // The runtime classloader will delegate to the parent MutableURLClassLoader
+      // (which already has this JAR), avoiding the child-first ClassCastException
+      // on Spark 4 where the REPL and SparkListener load different class copies.
+      sparkILoop.intp.global.extendCompilerClassPath(url)
+    } else {
+      sparkILoop.intp.addUrlsToClassPath(url)
+    }
   }
 
   override protected def isStarted(): Boolean = {


### PR DESCRIPTION
…th only

Use global.extendCompilerClassPath instead of addUrlsToClassPath for prophecy-libs so the REPL compiler can resolve the classes but the REPL runtime classloader does not get its own copy. At runtime the REPL classloader delegates to the parent MutableURLClassLoader, giving executors and the SparkListener the same class identity.

## What changes were proposed in this pull request?

(Please fill in changes proposed in this fix)
(Include a link to the associated JIRA and make sure to add a link to this pr on the JIRA as well)

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)
(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

Please review https://livy.incubator.apache.org/community/ before opening a pull request.
