### PR TITLE
[2] add prophecy-libs to compiler classpath

### DIFF
--- a/repl/scala-2.13/src/main/scala/org/apache/livy/repl/SparkInterpreter.scala
+++ b/repl/scala-2.13/src/main/scala/org/apache/livy/repl/SparkInterpreter.scala
@@ -22,6 +22,7 @@ import java.net.{URL, URLClassLoader}
 import java.nio.file.{Files, Paths}
 
 import scala.tools.nsc.GenericRunnerSettings
+import scala.tools.nsc.interpreter.IMain
 import scala.tools.nsc.interpreter.Results
 import scala.tools.nsc.interpreter.Results.Result
 
@@ -89,7 +90,7 @@ class SparkInterpreter(protected override val conf: SparkConf) extends AbstractS
           sparkILoop.intp.addUrlsToClassPath(otherJars: _*)
           if (prophecyJars.nonEmpty) {
             prophecyJars.foreach { p => debug(s"Adding $p to compiler classpath only...") }
-            sparkILoop.intp.global.extendCompilerClassPath(prophecyJars: _*)
+            sparkILoop.intp.asInstanceOf[IMain].global.extendCompilerClassPath(prophecyJars: _*)
           }
           classLoader = null
         } else {
@@ -117,7 +118,7 @@ class SparkInterpreter(protected override val conf: SparkConf) extends AbstractS
       // The runtime classloader will delegate to the parent MutableURLClassLoader
       // (which already has this JAR), avoiding the child-first ClassCastException
       // on Spark 4 where the REPL and SparkListener load different class copies.
-      sparkILoop.intp.global.extendCompilerClassPath(url)
+      sparkILoop.intp.asInstanceOf[IMain].global.extendCompilerClassPath(url)
     } else {
       sparkILoop.intp.addUrlsToClassPath(url)
     }


### PR DESCRIPTION
…th only

Use global.extendCompilerClassPath instead of addUrlsToClassPath for prophecy-libs so the REPL compiler can resolve the classes but the REPL runtime classloader does not get its own copy. At runtime the REPL classloader delegates to the parent MutableURLClassLoader, giving executors and the SparkListener the same class identity.

## What changes were proposed in this pull request?

(Please fill in changes proposed in this fix)
(Include a link to the associated JIRA and make sure to add a link to this pr on the JIRA as well)

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)
(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

Please review https://livy.incubator.apache.org/community/ before opening a pull request.
