### PR TITLE
keep prophecy-libs only in REPL classloader (not MutableClassLoader)

### DIFF
--- a/repl/scala-2.13/src/main/scala/org/apache/livy/repl/SparkInterpreter.scala
+++ b/repl/scala-2.13/src/main/scala/org/apache/livy/repl/SparkInterpreter.scala
@@ -22,7 +22,6 @@ import java.net.{URL, URLClassLoader}
 import java.nio.file.{Files, Paths}
 
 import scala.tools.nsc.GenericRunnerSettings
-import scala.tools.nsc.interpreter.IMain
 import scala.tools.nsc.interpreter.Results
 import scala.tools.nsc.interpreter.Results.Result
 
@@ -82,16 +81,12 @@ class SparkInterpreter(protected override val conf: SparkConf) extends AbstractS
             .filterNot { u =>
               Paths.get(u.toURI).getFileName.toString.contains("org.scala-lang_scala-reflect")
             }
+            .filterNot { u =>
+              Paths.get(u.toURI).getFileName.toString.contains("prophecy-libs")
+            }
 
-          val (prophecyJars, otherJars) = extraJarPath.partition { u =>
-            Paths.get(u.toURI).getFileName.toString.contains("prophecy-libs")
-          }
-          otherJars.foreach { p => debug(s"Adding $p to Scala interpreter's class path...") }
-          sparkILoop.intp.addUrlsToClassPath(otherJars: _*)
-          if (prophecyJars.nonEmpty) {
-            prophecyJars.foreach { p => debug(s"Adding $p to compiler classpath only...") }
-            sparkILoop.intp.asInstanceOf[IMain].global.extendCompilerClassPath(prophecyJars: _*)
-          }
+          extraJarPath.foreach { p => debug(s"Adding $p to Scala interpreter's class path...") }
+          sparkILoop.intp.addUrlsToClassPath(extraJarPath: _*)
           classLoader = null
         } else {
           classLoader = classLoader.getParent
@@ -112,16 +107,7 @@ class SparkInterpreter(protected override val conf: SparkConf) extends AbstractS
   }
 
   override def addJar(jar: String): Unit = {
-    val url = new URL(jar)
-    if (jar.contains("prophecy-libs")) {
-      // Add to compiler classpath only — not the REPL runtime classloader.
-      // The runtime classloader will delegate to the parent MutableURLClassLoader
-      // (which already has this JAR), avoiding the child-first ClassCastException
-      // on Spark 4 where the REPL and SparkListener load different class copies.
-      sparkILoop.intp.asInstanceOf[IMain].global.extendCompilerClassPath(url)
-    } else {
-      sparkILoop.intp.addUrlsToClassPath(url)
-    }
+    sparkILoop.intp.addUrlsToClassPath(new URL(jar))
   }
 
   override protected def isStarted(): Boolean = {

--- a/repl/src/main/scala/org/apache/livy/repl/ReplDriver.scala
+++ b/repl/src/main/scala/org/apache/livy/repl/ReplDriver.scala
@@ -23,6 +23,9 @@ import scala.concurrent.duration.Duration
 import io.netty.channel.ChannelHandlerContext
 import org.apache.spark.SparkConf
 
+import java.io.File
+import java.net.MalformedURLException
+
 import org.apache.livy.{EOLUtils, Logging}
 import org.apache.livy.client.common.ClientConf
 import org.apache.livy.rsc.{BaseProtocol, ReplJobResults, RSCConf}
@@ -117,6 +120,21 @@ class ReplDriver(conf: SparkConf, livyConf: RSCConf)
       }
     }
     super.addFile(path)
+  }
+
+  // Spark 4's REPL classloader (TranslatingClassLoader → ScalaClassLoader$URLClassLoader)
+  // is disconnected from Livy's MutableClassLoader. When prophecy-libs is added to BOTH,
+  // each classloader loads its own copy of the same class, causing ClassCastException when
+  // objects cross the boundary (e.g. InterimRow created by one CL cast via another).
+  // Fix: skip adding prophecy-libs to MutableClassLoader so it only lives in the REPL CL.
+  @throws[MalformedURLException]
+  override def addLocalFileToClassLoader(localCopy: File): Unit = {
+    if (localCopy.getName.contains("prophecy-libs")) {
+      info(s"Skipping MutableClassLoader addition for ${localCopy.getName} " +
+        "(REPL-classloader-only to prevent ClassCastException)")
+    } else {
+      super.addLocalFileToClassLoader(localCopy)
+    }
   }
 
   override protected def addJarOrPyFile(path: String): String = {


### PR DESCRIPTION
## Summary
- Reverts previous approach of excluding prophecy-libs from REPL classloader (broke `MetricsCollector.initializeMetrics` and `initialise.scala` imports)
- Instead, overrides `addLocalFileToClassLoader` in `ReplDriver` to skip prophecy-libs from Livy's `MutableClassLoader`
- prophecy-libs now lives ONLY in the REPL classloader → single copy → no ClassCastException

## Root Cause
In Spark 4, the REPL classloader chain (`TranslatingClassLoader → ScalaClassLoader$URLClassLoader → AppClassLoader`) is disconnected from Livy's `MutableClassLoader`. When prophecy-libs was added to both, each loaded its own copy of the same class → `ClassCastException` on `InterimRow`.

## Test plan
- [ ] Rebuild Livy Docker image from this branch
- [ ] Create session with HTTP-based prophecy-libs JAR
- [ ] Verify `MetricsCollector.initializeMetrics(spark)` succeeds (initialise.scala)
- [ ] Verify DataFrame operations work without ClassCastException
- [ ] Verify interims are collected in ALL mode