### PR TITLE
fix: add spark.jars to REPL classpath for Spark 4 sessions

### DIFF
--- a/repl/scala-2.13/src/main/scala/org/apache/livy/repl/SparkInterpreter.scala
+++ b/repl/scala-2.13/src/main/scala/org/apache/livy/repl/SparkInterpreter.scala
@@ -81,9 +81,6 @@ class SparkInterpreter(protected override val conf: SparkConf) extends AbstractS
             .filterNot { u =>
               Paths.get(u.toURI).getFileName.toString.contains("org.scala-lang_scala-reflect")
             }
-            .filterNot { u =>
-              Paths.get(u.toURI).getFileName.toString.contains("prophecy-libs")
-            }
 
           extraJarPath.foreach { p => debug(s"Adding $p to Scala interpreter's class path...") }
           sparkILoop.intp.addUrlsToClassPath(extraJarPath: _*)
@@ -107,11 +104,7 @@ class SparkInterpreter(protected override val conf: SparkConf) extends AbstractS
   }
 
   override def addJar(jar: String): Unit = {
-    if (jar.contains("prophecy-libs")) {
-      info(s"Skipping REPL classpath addition for $jar (parent-classloader-only)")
-    } else {
-      sparkILoop.intp.addUrlsToClassPath(new URL(jar))
-    }
+    sparkILoop.intp.addUrlsToClassPath(new URL(jar))
   }
 
   override protected def isStarted(): Boolean = {

--- a/repl/scala-2.13/src/main/scala/org/apache/livy/repl/SparkInterpreter.scala
+++ b/repl/scala-2.13/src/main/scala/org/apache/livy/repl/SparkInterpreter.scala
@@ -22,7 +22,6 @@ import java.net.{URL, URLClassLoader}
 import java.nio.file.{Files, Paths}
 
 import scala.tools.nsc.GenericRunnerSettings
-import scala.tools.nsc.interpreter.IMain
 import scala.tools.nsc.interpreter.Results
 import scala.tools.nsc.interpreter.Results.Result
 
@@ -82,16 +81,12 @@ class SparkInterpreter(protected override val conf: SparkConf) extends AbstractS
             .filterNot { u =>
               Paths.get(u.toURI).getFileName.toString.contains("org.scala-lang_scala-reflect")
             }
+            .filterNot { u =>
+              Paths.get(u.toURI).getFileName.toString.contains("prophecy-libs")
+            }
 
-          val (prophecyJars, otherJars) = extraJarPath.partition { u =>
-            Paths.get(u.toURI).getFileName.toString.contains("prophecy-libs")
-          }
-          otherJars.foreach { p => debug(s"Adding $p to Scala interpreter's class path...") }
-          sparkILoop.intp.addUrlsToClassPath(otherJars: _*)
-          if (prophecyJars.nonEmpty) {
-            prophecyJars.foreach { p => debug(s"Adding $p to compiler classpath only...") }
-            sparkILoop.intp.asInstanceOf[IMain].global.extendCompilerClassPath(prophecyJars: _*)
-          }
+          extraJarPath.foreach { p => debug(s"Adding $p to Scala interpreter's class path...") }
+          sparkILoop.intp.addUrlsToClassPath(extraJarPath: _*)
           classLoader = null
         } else {
           classLoader = classLoader.getParent
@@ -112,16 +107,7 @@ class SparkInterpreter(protected override val conf: SparkConf) extends AbstractS
   }
 
   override def addJar(jar: String): Unit = {
-    val url = new URL(jar)
-    if (jar.contains("prophecy-libs")) {
-      // Add to compiler classpath only — not the REPL runtime classloader.
-      // The runtime classloader will delegate to the parent MutableURLClassLoader
-      // (which already has this JAR), avoiding the child-first ClassCastException
-      // on Spark 4 where the REPL and SparkListener load different class copies.
-      sparkILoop.intp.asInstanceOf[IMain].global.extendCompilerClassPath(url)
-    } else {
-      sparkILoop.intp.addUrlsToClassPath(url)
-    }
+    sparkILoop.intp.addUrlsToClassPath(new URL(jar))
   }
 
   override protected def isStarted(): Boolean = {

--- a/repl/scala-2.13/src/main/scala/org/apache/livy/repl/SparkInterpreter.scala
+++ b/repl/scala-2.13/src/main/scala/org/apache/livy/repl/SparkInterpreter.scala
@@ -22,6 +22,7 @@ import java.net.{URL, URLClassLoader}
 import java.nio.file.{Files, Paths}
 
 import scala.tools.nsc.GenericRunnerSettings
+import scala.tools.nsc.interpreter.IMain
 import scala.tools.nsc.interpreter.Results
 import scala.tools.nsc.interpreter.Results.Result
 
@@ -89,7 +90,7 @@ class SparkInterpreter(protected override val conf: SparkConf) extends AbstractS
           sparkILoop.intp.addUrlsToClassPath(otherJars: _*)
           if (prophecyJars.nonEmpty) {
             prophecyJars.foreach { p => debug(s"Adding $p to compiler classpath only...") }
-            sparkILoop.intp.global.extendCompilerClassPath(prophecyJars: _*)
+            sparkILoop.intp.asInstanceOf[IMain].global.extendCompilerClassPath(prophecyJars: _*)
           }
           classLoader = null
         } else {
@@ -117,7 +118,7 @@ class SparkInterpreter(protected override val conf: SparkConf) extends AbstractS
       // The runtime classloader will delegate to the parent MutableURLClassLoader
       // (which already has this JAR), avoiding the child-first ClassCastException
       // on Spark 4 where the REPL and SparkListener load different class copies.
-      sparkILoop.intp.global.extendCompilerClassPath(url)
+      sparkILoop.intp.asInstanceOf[IMain].global.extendCompilerClassPath(url)
     } else {
       sparkILoop.intp.addUrlsToClassPath(url)
     }

--- a/repl/scala-2.13/src/main/scala/org/apache/livy/repl/SparkInterpreter.scala
+++ b/repl/scala-2.13/src/main/scala/org/apache/livy/repl/SparkInterpreter.scala
@@ -72,9 +72,11 @@ class SparkInterpreter(protected override val conf: SparkConf) extends AbstractS
 
     restoreContextClassLoader {
       var classLoader = Thread.currentThread().getContextClassLoader
+      var foundMutableURLCL = false
       while (classLoader != null) {
         if (classLoader.getClass.getCanonicalName ==
           "org.apache.spark.util.MutableURLClassLoader") {
+          foundMutableURLCL = true
           val extraJarPath = classLoader.asInstanceOf[URLClassLoader].getURLs()
             .filter { u => u.getProtocol == "file" && new File(u.getPath).isFile }
             .filterNot { u => Paths.get(u.toURI).getFileName.toString.startsWith("livy-") }
@@ -90,6 +92,45 @@ class SparkInterpreter(protected override val conf: SparkConf) extends AbstractS
           classLoader = null
         } else {
           classLoader = classLoader.getParent
+        }
+      }
+
+      // Spark 4 has no MutableURLClassLoader — initial session JARs from spark.jars
+      // are registered with SparkContext but not added to any classloader.
+      // Find the local copies SparkContext downloaded and add them to the REPL.
+      if (!foundMutableURLCL) {
+        val sparkJars = conf.getOption("spark.jars").toSeq
+          .flatMap(_.split(","))
+          .map(_.trim)
+          .filter(_.nonEmpty)
+
+        if (sparkJars.nonEmpty) {
+          val sparkLocalDir = new File(conf.get("spark.local.dir", System.getProperty("java.io.tmpdir")))
+          val sparkDirs = Option(sparkLocalDir.listFiles())
+            .getOrElse(Array.empty)
+            .filter(f => f.isDirectory && f.getName.startsWith("spark-"))
+
+          val localUrls = sparkJars.flatMap { jarUri =>
+            val jarName = jarUri.split("/").last.split("\\?").head
+            val localCopy = sparkDirs.flatMap { dir =>
+              val candidate = new File(dir, jarName)
+              if (candidate.isFile) Some(candidate) else None
+            }.headOption
+            localCopy match {
+              case Some(f) =>
+                info(s"Found local copy for $jarName: ${f.getAbsolutePath}")
+                Some(f.toURI.toURL)
+              case None =>
+                warn(s"No local copy found for spark.jars entry: $jarUri")
+                None
+            }
+          }
+
+          if (localUrls.nonEmpty) {
+            info(s"No MutableURLClassLoader found (Spark 4). " +
+              s"Adding ${localUrls.size} JARs from spark.jars to REPL classpath.")
+            sparkILoop.intp.addUrlsToClassPath(localUrls: _*)
+          }
         }
       }
 

--- a/repl/scala-2.13/src/main/scala/org/apache/livy/repl/SparkInterpreter.scala
+++ b/repl/scala-2.13/src/main/scala/org/apache/livy/repl/SparkInterpreter.scala
@@ -82,8 +82,15 @@ class SparkInterpreter(protected override val conf: SparkConf) extends AbstractS
               Paths.get(u.toURI).getFileName.toString.contains("org.scala-lang_scala-reflect")
             }
 
-          extraJarPath.foreach { p => debug(s"Adding $p to Scala interpreter's class path...") }
-          sparkILoop.intp.addUrlsToClassPath(extraJarPath: _*)
+          val (prophecyJars, otherJars) = extraJarPath.partition { u =>
+            Paths.get(u.toURI).getFileName.toString.contains("prophecy-libs")
+          }
+          otherJars.foreach { p => debug(s"Adding $p to Scala interpreter's class path...") }
+          sparkILoop.intp.addUrlsToClassPath(otherJars: _*)
+          if (prophecyJars.nonEmpty) {
+            prophecyJars.foreach { p => debug(s"Adding $p to compiler classpath only...") }
+            sparkILoop.intp.global.extendCompilerClassPath(prophecyJars: _*)
+          }
           classLoader = null
         } else {
           classLoader = classLoader.getParent
@@ -104,7 +111,16 @@ class SparkInterpreter(protected override val conf: SparkConf) extends AbstractS
   }
 
   override def addJar(jar: String): Unit = {
-    sparkILoop.intp.addUrlsToClassPath(new URL(jar))
+    val url = new URL(jar)
+    if (jar.contains("prophecy-libs")) {
+      // Add to compiler classpath only — not the REPL runtime classloader.
+      // The runtime classloader will delegate to the parent MutableURLClassLoader
+      // (which already has this JAR), avoiding the child-first ClassCastException
+      // on Spark 4 where the REPL and SparkListener load different class copies.
+      sparkILoop.intp.global.extendCompilerClassPath(url)
+    } else {
+      sparkILoop.intp.addUrlsToClassPath(url)
+    }
   }
 
   override protected def isStarted(): Boolean = {

--- a/repl/scala-2.13/src/main/scala/org/apache/livy/repl/SparkInterpreter.scala
+++ b/repl/scala-2.13/src/main/scala/org/apache/livy/repl/SparkInterpreter.scala
@@ -81,6 +81,9 @@ class SparkInterpreter(protected override val conf: SparkConf) extends AbstractS
             .filterNot { u =>
               Paths.get(u.toURI).getFileName.toString.contains("org.scala-lang_scala-reflect")
             }
+            .filterNot { u =>
+              Paths.get(u.toURI).getFileName.toString.contains("prophecy-libs")
+            }
 
           extraJarPath.foreach { p => debug(s"Adding $p to Scala interpreter's class path...") }
           sparkILoop.intp.addUrlsToClassPath(extraJarPath: _*)
@@ -104,7 +107,11 @@ class SparkInterpreter(protected override val conf: SparkConf) extends AbstractS
   }
 
   override def addJar(jar: String): Unit = {
-    sparkILoop.intp.addUrlsToClassPath(new URL(jar))
+    if (jar.contains("prophecy-libs")) {
+      info(s"Skipping REPL classpath addition for $jar (parent-classloader-only)")
+    } else {
+      sparkILoop.intp.addUrlsToClassPath(new URL(jar))
+    }
   }
 
   override protected def isStarted(): Boolean = {

--- a/repl/src/main/scala/org/apache/livy/repl/ReplDriver.scala
+++ b/repl/src/main/scala/org/apache/livy/repl/ReplDriver.scala
@@ -23,6 +23,9 @@ import scala.concurrent.duration.Duration
 import io.netty.channel.ChannelHandlerContext
 import org.apache.spark.SparkConf
 
+import java.io.File
+import java.net.MalformedURLException
+
 import org.apache.livy.{EOLUtils, Logging}
 import org.apache.livy.client.common.ClientConf
 import org.apache.livy.rsc.{BaseProtocol, ReplJobResults, RSCConf}
@@ -117,6 +120,21 @@ class ReplDriver(conf: SparkConf, livyConf: RSCConf)
       }
     }
     super.addFile(path)
+  }
+
+  // Spark 4's REPL classloader (TranslatingClassLoader → ScalaClassLoader$URLClassLoader)
+  // is disconnected from Livy's MutableClassLoader. When prophecy-libs is added to BOTH,
+  // each classloader loads its own copy of the same class, causing ClassCastException when
+  // objects cross the boundary (e.g. InterimRow created by one CL cast via another).
+  // Fix: skip adding prophecy-libs to MutableClassLoader so it only lives in the REPL CL.
+  @throws[MalformedURLException]
+  override def addLocalFileToClassLoader(localCopy: File): Unit = {
+    if (localCopy.getName.contains("prophecy-libs")) {
+      info(s"Skipping MutableClassLoader addition for ${localCopy.getName} " +
+        "(REPL-classloader-only to prevent ClassCastException)")
+    } else {
+      super.addLocalFileToClassLoader(localCopy)
+    }
   }
 
   override protected def addJarOrPyFile(path: String): String = {


### PR DESCRIPTION
## Summary
- In Spark 4, `MutableURLClassLoader` does not exist, so initial session JARs specified via `spark.jars` are registered with SparkContext but never added to any classloader
- This causes `ClassNotFoundException` for prophecy-libs classes (e.g. `MetricsCollector`) when the REPL initialization code runs
- When `MutableURLClassLoader` is not found (Spark 4), this fix finds the local copies SparkContext downloaded in `spark.local.dir` and adds them to the REPL classpath

## Context
- PR #25 fixed the `ClassCastException` by preventing prophecy-libs from being loaded into Livy's `MutableClassLoader`
- That fix correctly handles JARs added post-session-creation (via `addJarOrPyFile`)
- However, initial session JARs go through `spark.jars` conf → SparkContext, which is a different code path that bypassed the REPL classloader entirely in Spark 4

## Test plan
- Deploy and verify prophecy-libs classes are loadable in the REPL
- Verify `MetricsCollector.isAvailable` check passes during session init
- Verify no `ClassCastException` (prophecy-libs should only be in REPL classloader)